### PR TITLE
[bugfix] mfc_set_pv multi holding registers write

### DIFF
--- a/bnct-app/src/modbus.c
+++ b/bnct-app/src/modbus.c
@@ -17,7 +17,7 @@
 ////// k_work to process coil/register commands
 struct ctrl_cmd_t {
   struct k_work work;
-  uint8_t addr;
+  uint16_t addr;
 };
 
 static struct ctrl_cmd_t coil_cmd = {.addr = ARRAY_SIZE(coil_reg)};

--- a/bnct-app/src/mode.c
+++ b/bnct-app/src/mode.c
@@ -21,7 +21,7 @@ static struct k_poll_signal mode_sig = K_POLL_SIGNAL_INITIALIZER(mode_sig);
 static struct k_poll_event mode_event = K_POLL_EVENT_INITIALIZER(
     K_POLL_TYPE_SIGNAL, K_POLL_MODE_NOTIFY_ONLY, &mode_sig);
 
-static void mode_holding_register_handler(uint8_t addr) {
+static void mode_holding_register_handler(uint16_t addr) {
   if (addr != REG_SET_MODE)
     return;
 

--- a/bnct-app/src/pump.c
+++ b/bnct-app/src/pump.c
@@ -20,7 +20,7 @@ static const uint32_t default_speed = DT_PROP(PUMP_NODE, default_speed); // unit
 // [todo] poll handler (present speed: REG_PUMP_SPEED_PV)
 
 // coil handler
-static void pump_coil_register_handler(uint8_t addr) {
+static void pump_coil_register_handler(uint16_t addr) {
 
   switch (addr) {
   case COIL_ONOFF_PUMP:
@@ -41,10 +41,12 @@ static void pump_coil_register_handler(uint8_t addr) {
 COIL_REG_HANDLER_DEFINE(pump_coil_reg, pump_coil_register_handler);
 
 // holding register handler
-static void pump_holding_register_handler(uint8_t addr) {
+static void pump_holding_register_handler(uint16_t addr) {
   if (addr == REG_PUMP_SPEED_SV && coil_reg[COIL_ONOFF_PUMP]->value) {
       pwm_set_pulse_dt(&pump, holding_reg[REG_PUMP_SPEED_SV]->value * step);
   }
+
+
   return;
 }
 

--- a/bnct-app/src/status.c
+++ b/bnct-app/src/status.c
@@ -21,7 +21,7 @@ static void status_timer_callback(struct k_timer *timer) {
 static K_TIMER_DEFINE(status_timer, status_timer_callback, NULL);
 
 /* holding register handler */
-static void status_holding_register_handler(uint8_t addr) {
+static void status_holding_register_handler(uint16_t addr) {
   if (addr == REG_UPDATE_INTERVAL) {
     k_timer_start(&status_timer, K_NO_WAIT, K_MSEC(holding_reg[addr]->value));
   }

--- a/bnct-app/src/valve.c
+++ b/bnct-app/src/valve.c
@@ -12,7 +12,7 @@
 
 static const struct gpio_dt_spec valve = GPIO_DT_SPEC_GET(VALVE_NODE, gpios);
 
-static void valve_coil_register_handler(uint8_t addr) {
+static void valve_coil_register_handler(uint16_t addr) {
   if (addr == COIL_ONOFF_VALVE) {
     gpio_pin_configure_dt(&valve, coil_reg[COIL_ONOFF_VALVE]->value
                                       ? GPIO_OUTPUT_ACTIVE

--- a/include/iterables/callback.h
+++ b/include/iterables/callback.h
@@ -16,7 +16,7 @@ struct status_handler_t {
 
 //
 struct coil_register_handler_t {
-  void (*const callback)(uint8_t addr);
+  void (*const callback)(uint16_t addr);
 };
 
 #define COIL_REG_HANDLER_DEFINE(_name, _cb)                                   \
@@ -27,7 +27,7 @@ struct coil_register_handler_t {
 
 //
 struct holding_register_handler_t {
-  void (*const callback)(uint8_t addr);
+  void (*const callback)(uint16_t addr);
 };
 
 #define HOLDING_REG_HANDLER_DEFINE(_name, _cb)                \

--- a/lib/acu20fd.c
+++ b/lib/acu20fd.c
@@ -26,7 +26,7 @@ static uint16_t __attribute__((unused)) acu20fd_analog_mode[] = {0x0000, 0x41C8}
 static uint16_t __attribute__((unused)) acu20fd_set_zero[] = {0x0000, 0x0000};
 static uint16_t __attribute__((unused)) acu20fd_cancel_zero[] = {0x3F80, 0x0000};
 
-#define ACU20FD_DEAD_TIME_MS 200
+#define ACU20FD_DEAD_TIME_MS 500
 
 /* set work mode: analog (digit_mode: false), digi (digit_mode: true) */
 int acu20fd_init(const int iface, const uint8_t uid, bool digit_mode) {


### PR DESCRIPTION
- no matter which part of registers are updated, always set the latest value to mfc
- wait 1 second for mfc power up
- increase mfc write wait time to 500 ms